### PR TITLE
fix: context API の扱いについて指摘された lint警告の解消及び型注釈のリファクタリング.

### DIFF
--- a/src/provider/GetFetchDataContextFragment.tsx
+++ b/src/provider/GetFetchDataContextFragment.tsx
@@ -1,0 +1,44 @@
+import { ReactNode, FC, useState } from "react";
+import { GetFetchDataContext } from "./GetFetchDataContext";
+import { pokeLists } from "../ts/GetFetchDataType";
+
+type fragmentType = {
+    children: ReactNode;
+};
+
+export const GetFetchDataContextFragment: FC<fragmentType> = ({ children }) => {
+    /**
+     * React では参照している Context が更新された時に（参照している各コンポーネントが）再レンダリングされるため、本来は機能・用途ごとにそれぞれ provider ファイルを分けて用意するべきだが今回は機能として「連携・連動している」のでまとめて記述している
+    */
+
+    /* コンテンツデータ格納用の配列 State */
+    const [isPokeData, setPokeData] = useState<pokeLists[]>([]);
+
+    /* 上限値（取得したコンテンツデータの総数） */
+    const [pagerLimitMaxNum, setPagerLimitMaxNum] = useState<number>(0);
+
+    /* ページャー数の管理用 State */
+    const [isPagers, setPagers] = useState<number>(0);
+
+    /* ページャーの offset 値 */
+    const [isOffSet] = useState<number>(50);
+
+    /* 現在表示中のページ番号 */
+    const [isCurrPage, setCurrPage] = useState<number>(1);
+
+    /* ローディング */
+    const [isLoading, setLoading] = useState<boolean>(false);
+
+    return (
+        <GetFetchDataContext.Provider value={{
+            isPokeData, setPokeData,
+            pagerLimitMaxNum, setPagerLimitMaxNum,
+            isPagers, setPagers,
+            isOffSet,
+            isCurrPage, setCurrPage,
+            isLoading, setLoading
+        }}>
+            {children}
+        </GetFetchDataContext.Provider>
+    );
+}

--- a/src/ts/GetFetchDataType.ts
+++ b/src/ts/GetFetchDataType.ts
@@ -1,14 +1,14 @@
 export type pokeAry = {
     name: string;
     url: string;
-}
+};
 
 export type pokeFetchData = {
     count: number;
     next?: number | null;
     previous?: number | null;
     results: pokeAry[];
-}
+};
 
 export type pokeLists = {
     id: number;
@@ -30,7 +30,7 @@ export type pokeLists = {
     species?: {
         url: string;
     };
-}
+};
 
 export type speciesItems = {
     genera: {
@@ -56,9 +56,9 @@ export type speciesItems = {
             };
         }) => string | undefined): speciesItems[];
     };
-}
+};
 
 export type pokeNameLocalJsonFile = {
     ja: string;
     en: string;
-}
+};


### PR DESCRIPTION
- context API の扱いについて指摘された lint警告の解消
  - `src/provider/GetFetchDataContextFragment.tsx`<br>`main.tsx`に読み込ませる部分を分離
- 型注釈のリファクタリング
  - `src/ts/GetFetchDataType.ts`<br>各型注釈の末尾にセミコロンを追加